### PR TITLE
[QUININE-44] Use mate alignment pos instead of alignment end.

### DIFF
--- a/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/targeted/ReadStats.scala
+++ b/quinine-core/src/main/scala/org/bdgenomics/quinine/metrics/targeted/ReadStats.scala
@@ -213,7 +213,7 @@ private[targeted] object ReadStats extends Serializable {
       val ourAlignment = ReferenceRegion(read)
       val pairAlignment = ReferenceRegion(read.getMateContig.getContigName,
         read.getMateAlignmentStart,
-        read.getMateAlignmentEnd)
+        read.getMateAlignmentStart + 1) // FIXME
 
       // do our alignments overlap?
       if (ourAlignment.overlaps(pairAlignment)) {


### PR DESCRIPTION
Resolves #44. Mate alignment end is not populated by ADAM, and thus throws an NPE when accessed in quinine.
